### PR TITLE
Add _LIGHTMAPPED_SPECULAR to DefaultConfig.hlsl

### DIFF
--- a/ShaderLibrary/DefaultConfig.hlsl
+++ b/ShaderLibrary/DefaultConfig.hlsl
@@ -14,6 +14,9 @@
 // Enable Bakery MonoSH
 // #define _BAKERY_MONOSH
 
+// Enable Lightmapped Specular
+// #define _LIGHTMAPPED_SPECULAR
+
 // Enable Bicubic Lightmap Filtering
 // #define _BICUBIC_LIGHTMAP
 


### PR DESCRIPTION
Noticed that lightmapped specular was missing in the graphlit defualt config compared to the lit config. Added it and tested in my project