### PR TITLE
feat: Add BIAS variants for SampleTexture and SampleTextureArray Nodes

### DIFF
--- a/Editor/ShaderNode/Nodes/Sampling/AbstractSampleTextureNode.cs
+++ b/Editor/ShaderNode/Nodes/Sampling/AbstractSampleTextureNode.cs
@@ -21,6 +21,7 @@ namespace Graphlit
         protected const int OUT_A = 7;
 
         protected const int LOD = 9;
+        protected const int BIAS = 10;
 
         public override Color Accent => new Color(0.8f, 0.2f, 0.2f);
 
@@ -29,6 +30,7 @@ namespace Graphlit
 
         public virtual IPortType TextureType => new Texture2DObject();
         public virtual bool HasLod => false;
+        public virtual bool HasBias => false;
         public virtual int Coords => 2;
         public virtual PortBinding UVBinding => PortBinding.UV0;
         public virtual string SampleMethod => $"SAMPLE_TEXTURE2D({PortData[TEX].Name}, {GetSamplerName(PortData[TEX].Name)}, {PortData[UV].Name})";
@@ -53,6 +55,11 @@ namespace Graphlit
             if (HasLod)
             {
                 AddPort(new(PortDirection.Input, new Float(1), LOD, "LOD"));
+            }
+
+            if (HasBias)
+            {
+                AddPort(new(PortDirection.Input, new Float(1), BIAS, "BIAS"));
             }
 
             Bind(UV, UVBinding);

--- a/Editor/ShaderNode/Nodes/Sampling/SampleTexture2DArrayNode.cs
+++ b/Editor/ShaderNode/Nodes/Sampling/SampleTexture2DArrayNode.cs
@@ -32,4 +32,19 @@ namespace Graphlit
             AddPort(new(PortDirection.Input, new Float(1), INDEX, "Index"));
         }
     }
+
+    [NodeInfo("Texture/Sample Texture 2D Array BIAS")]
+    public class SampleTexture2DArrayBiasNode : SampleTextureNode
+    {
+        const int INDEX = 10;
+        public override IPortType TextureType => new Texture2DArrayObject();
+        public override bool HasBias => true;
+        public override string SampleMethod => $"SAMPLE_TEXTURE2D_ARRAY_BIAS({PortData[TEX].Name}, {GetSamplerName(PortData[TEX].Name)}, {PortData[UV].Name}, {PortData[INDEX].Name}, {PortData[BIAS].Name})";
+
+        public override void Initialize()
+        {
+            base.Initialize();
+            AddPort(new(PortDirection.Input, new Float(1), INDEX, "Index"));
+        }
+    }
 }

--- a/Editor/ShaderNode/Nodes/Sampling/SampleTexture2DArrayNode.cs
+++ b/Editor/ShaderNode/Nodes/Sampling/SampleTexture2DArrayNode.cs
@@ -36,7 +36,7 @@ namespace Graphlit
     [NodeInfo("Texture/Sample Texture 2D Array BIAS")]
     public class SampleTexture2DArrayBiasNode : SampleTextureNode
     {
-        const int INDEX = 10;
+        const int INDEX = 11;
         public override IPortType TextureType => new Texture2DArrayObject();
         public override bool HasBias => true;
         public override string SampleMethod => $"SAMPLE_TEXTURE2D_ARRAY_BIAS({PortData[TEX].Name}, {GetSamplerName(PortData[TEX].Name)}, {PortData[UV].Name}, {PortData[INDEX].Name}, {PortData[BIAS].Name})";

--- a/Editor/ShaderNode/Nodes/Sampling/SampleTexture2DNode.cs
+++ b/Editor/ShaderNode/Nodes/Sampling/SampleTexture2DNode.cs
@@ -26,4 +26,11 @@ namespace Graphlit
         public override bool HasLod => true;
         public override string SampleMethod => $"SAMPLE_TEXTURE2D_LOD({PortData[TEX].Name}, {GetSamplerName(PortData[TEX].Name)}, {PortData[UV].Name}, {PortData[LOD].Name})";
     }
+
+    [NodeInfo("Texture/Sample Texture 2D BIAS"), System.Serializable]
+    public class SampleTexture2DBiasNode : SampleTexture2DNode
+    {
+        public override bool HasBias => true;
+        public override string SampleMethod => $"SAMPLE_TEXTURE2D_BIAS({PortData[TEX].Name}, {GetSamplerName(PortData[TEX].Name)}, {PortData[UV].Name}, {PortData[BIAS].Name})";
+    }
 }


### PR DESCRIPTION
I needed this and saw they werent available yet. Was simple to add and works nicely!
For the texture array implementation I had to increment the value of the index port, maybe there is a nicer way to do it.