### PR TITLE
Support Unity 6.5

### DIFF
--- a/Editor/Generation/PassBuilder.cs
+++ b/Editor/Generation/PassBuilder.cs
@@ -664,8 +664,11 @@ namespace Graphlit
                         if (ta == null && tb == null) return 0;
                         if (ta == null) return -1;
                         if (tb == null) return 1;
-
+#if UNITY_6000_5_OR_NEWER
+                        return ta.GetEntityId().CompareTo(tb.GetEntityId());
+#else
                         return ta.GetInstanceID().CompareTo(tb.GetInstanceID());
+#endif
                     });
 
 

--- a/Editor/Importer/GraphlitImporter.cs
+++ b/Editor/Importer/GraphlitImporter.cs
@@ -15,6 +15,7 @@ namespace Graphlit
     public class GraphlitImporter : ScriptedImporter
     {
         internal static Dictionary<string, ShaderGraphView> _graphViews = new();
+        private const string _newGraphName = "New Shader Graph.graphlit";
 
         public static Texture2D Thumbnail => AssetDatabase.LoadAssetAtPath<Texture2D>("Packages/com.z3y.graphlit/Editor/icon.psd");
 
@@ -125,7 +126,11 @@ namespace Graphlit
             var graph = ReadGraphData(AssetDatabase.AssetPathToGUID(samplePath));
             graph.data.shaderName = "Default Shader";
             var jsonData = EditorJsonUtility.ToJson(graph, true);
-            ProjectWindowUtil.CreateAssetWithContent($"New Graphlit Shader.graphlit", jsonData);
+#if UNITY_6000_5_OR_NEWER
+            ProjectWindowUtil.CreateAssetWithTextContent(_newGraphName, jsonData);
+#else
+            ProjectWindowUtil.CreateAssetWithContent(_newGraphName, jsonData);
+#endif
         }
         public static void CreateEmptyTemplate<T>() where T : TemplateOutput, new()
         {
@@ -140,7 +145,11 @@ namespace Graphlit
             graph.data.shaderName = "Default Shader";
 
             var jsonData = EditorJsonUtility.ToJson(graph, true);
-            ProjectWindowUtil.CreateAssetWithContent($"New Shader Graph.graphlit", jsonData);
+#if UNITY_6000_5_OR_NEWER
+            ProjectWindowUtil.CreateAssetWithTextContent(_newGraphName, jsonData);
+#else
+            ProjectWindowUtil.CreateAssetWithContent(_newGraphName, jsonData);
+#endif
         }
 
         public static void OpenInGraphView(string guid)
@@ -189,10 +198,24 @@ namespace Graphlit
             }
         }
 
+#if UNITY_6000_5_OR_NEWER
+        [OnOpenAsset]
+        public static bool OnOpenAsset(EntityId entityId, int line)
+        {
+            var unityObject = EditorUtility.EntityIdToObject(entityId);
+            return OnOpenAssetImpl(unityObject, line);
+        }
+#else
         [OnOpenAsset]
         public static bool OnOpenAsset(int instanceID, int line)
         {
             var unityObject = EditorUtility.InstanceIDToObject(instanceID);
+            return OnOpenAssetImpl(unityObject, line);
+        }
+#endif
+
+        public static bool OnOpenAssetImpl(UnityEngine.Object unityObject, int line)
+        {
             var path = AssetDatabase.GetAssetPath(unityObject);
             var importer = AssetImporter.GetAtPath(path);
             if (importer is not GraphlitImporter shaderGraphImporter)

--- a/Editor/Importer/SubGraphlitImporter.cs
+++ b/Editor/Importer/SubGraphlitImporter.cs
@@ -8,6 +8,8 @@ namespace Graphlit
     [ScriptedImporter(9, new[] { "subgraphlit" }, -1)]
     public class SubGraphlitImporter : GraphlitImporter
     {
+        private const string _newSubgraphName = "Subgraph.subgraphlit";
+
         internal static void BuildSubgraph(AssetImportContext ctx)
         {
             ctx.AddObjectToAsset("Subgraph Asset", ScriptableObject.CreateInstance<SubgraphObject>());
@@ -20,7 +22,11 @@ namespace Graphlit
             var graph = ReadGraphData(AssetDatabase.AssetPathToGUID(samplePath));
 
             var jsonData = EditorJsonUtility.ToJson(graph, true);
-            ProjectWindowUtil.CreateAssetWithContent($"Subgraph.subgraphlit", jsonData);
+#if UNITY_6000_5_OR_NEWER
+            ProjectWindowUtil.CreateAssetWithTextContent(_newSubgraphName, jsonData);
+#else
+            ProjectWindowUtil.CreateAssetWithContent(_newSubgraphName, jsonData);
+#endif
         }
     }
 }

--- a/Editor/Importer/VariantImporter.cs
+++ b/Editor/Importer/VariantImporter.cs
@@ -14,6 +14,8 @@ namespace Graphlit
         [SerializeField] public bool depthFillPass = false;
         [SerializeField] public string nameSuffix = "Variant";
 
+        private const string _newVariantName = "Graphlit Variant.graphlitvariant";
+
         internal void OverrideVariantData(GraphData data)
         {
             data.shaderName += " " + nameSuffix;
@@ -56,7 +58,11 @@ namespace Graphlit
         [MenuItem("Assets/Create/Graphlit/Variant")]
         public static void CreateVariantFile()
         {
-            ProjectWindowUtil.CreateAssetWithContent($"Graphlit Variant.graphlitvariant", "");
+#if UNITY_6000_5_OR_NEWER
+            ProjectWindowUtil.CreateAssetWithTextContent(_newVariantName, "");
+#else
+            ProjectWindowUtil.CreateAssetWithContent(_newVariantName, "");
+#endif
         }
     }
 }

--- a/Editor/ShaderNode/Nodes/CustomFunctionNode.cs
+++ b/Editor/ShaderNode/Nodes/CustomFunctionNode.cs
@@ -13,11 +13,16 @@ namespace Graphlit
     [NodeInfo("Input/Custom Function"), Serializable]
     public class CustomFunctionNode : ShaderNode
     {
+        private const string _customFileName = "CustomFunction.hlsl";
         public static readonly string[] Tag = new[] { "GraphlitFunction", "ZSGFunction" };
         [MenuItem("Assets/Create/Graphlit/Shader Include", priority = -1)]
         public static void CreateVariantFile()
         {
-            ProjectWindowUtil.CreateAssetWithContent("CustomFunction.hlsl", DefaultFunction);
+#if UNITY_6000_5_OR_NEWER
+            ProjectWindowUtil.CreateAssetWithTextContent(_customFileName, DefaultFunction);
+#else
+            ProjectWindowUtil.CreateAssetWithContent(_customFileName, DefaultFunction);
+#endif
             var include = new ShaderInclude();
             AssetDatabase.SetLabels(include, new[] { Tag[0] });
         }


### PR DESCRIPTION
Unity 6.5 removes `GetInstanceId()` in favor of the new EntityId methods.
